### PR TITLE
Add message queuing in CAN manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# can_soft
+# CAN Soft Module
+
+This repository contains a portable CAN bus management module written in pure C. The module allows the use of multiple CAN controllers simultaneously via a common `ICANDriver` interface. Example drivers for MCP2515 and STM32 bxCAN are provided as stubs.
+
+## Directory structure
+
+```
+can/
+├── can_autobaud.c/h    - auto baudrate detection helper
+├── can_config.h        - default configuration values
+├── can_interface.h     - abstract ICANDriver definition
+├── can_manager.c/h     - manager for multiple CAN instances
+├── can_mcp2515.c/h     - stub driver for MCP2515 controller
+├── can_stm32_bxcan.c/h - stub driver for STM32 bxCAN controller
+└── can_test.c          - usage example
+```
+
+## Features
+
+- Multiple CAN interfaces selectable at runtime
+- Built-in transmit and receive queues with event callbacks
+
+## Building example
+
+A very small `can_test.c` demonstrates adding two interfaces, queuing a message, processing the manager and triggering autobaud.
+
+```
+cc can/*.c -o can_test
+./can_test
+```

--- a/can/can_autobaud.c
+++ b/can/can_autobaud.c
@@ -1,0 +1,13 @@
+#include "can_autobaud.h"
+#include <stddef.h>
+
+CAN_Result_t CAN_Autobaud_Detect(ICANDriver *driver, const uint32_t *rates, uint8_t num)
+{
+    if (!driver || !rates || !driver->set_mode || !driver->auto_baud_detect)
+        return CAN_ERROR;
+    /* Put driver in listen-only mode if supported */
+    driver->set_mode(driver, CAN_MODE_SILENT);
+    CAN_Result_t res = driver->auto_baud_detect(driver, rates, num);
+    driver->set_mode(driver, CAN_MODE_NORMAL);
+    return res;
+}

--- a/can/can_autobaud.h
+++ b/can/can_autobaud.h
@@ -1,0 +1,17 @@
+#ifndef CAN_AUTOBAUD_H
+#define CAN_AUTOBAUD_H
+
+#include <stdint.h>
+#include "can_interface.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+CAN_Result_t CAN_Autobaud_Detect(ICANDriver *driver, const uint32_t *rates, uint8_t num);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CAN_AUTOBAUD_H */

--- a/can/can_config.h
+++ b/can/can_config.h
@@ -1,0 +1,18 @@
+#ifndef CAN_CONFIG_H
+#define CAN_CONFIG_H
+
+#include <stdint.h>
+
+#define CAN_MAX_BITRATES 5
+
+static const uint32_t default_bitrates[CAN_MAX_BITRATES] = {125000, 250000, 500000, 1000000, 0};
+
+#ifndef CAN_TX_QUEUE_LEN
+#define CAN_TX_QUEUE_LEN 16
+#endif
+
+#ifndef CAN_RX_QUEUE_LEN
+#define CAN_RX_QUEUE_LEN 16
+#endif
+
+#endif /* CAN_CONFIG_H */

--- a/can/can_interface.h
+++ b/can/can_interface.h
@@ -1,0 +1,53 @@
+#ifndef CAN_INTERFACE_H
+#define CAN_INTERFACE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    CAN_MODE_NORMAL,
+    CAN_MODE_SILENT,
+    CAN_MODE_LOOPBACK,
+    CAN_MODE_AUTOBAUD
+} CAN_Mode_t;
+
+typedef struct {
+    uint32_t bitrate;
+    uint32_t filter_id;
+    uint32_t filter_mask;
+    CAN_Mode_t mode;
+} CAN_Config_t;
+
+typedef enum {
+    CAN_OK = 0,
+    CAN_ERROR
+} CAN_Result_t;
+
+typedef struct ICANDriver ICANDriver;
+
+typedef struct {
+    uint32_t id;
+    uint8_t dlc;
+    uint8_t data[8];
+    uint8_t extended;
+} CAN_Message_t;
+
+struct ICANDriver {
+    CAN_Result_t (*init)(ICANDriver *driver, const CAN_Config_t *config);
+    CAN_Result_t (*send)(ICANDriver *driver, const CAN_Message_t *msg, uint32_t timeout_ms);
+    CAN_Result_t (*receive)(ICANDriver *driver, CAN_Message_t *msg);
+    CAN_Result_t (*set_filter)(ICANDriver *driver, uint32_t id, uint32_t mask);
+    CAN_Result_t (*set_mode)(ICANDriver *driver, CAN_Mode_t mode);
+    uint32_t     (*get_error_state)(ICANDriver *driver);
+    CAN_Result_t (*auto_baud_detect)(ICANDriver *driver, const uint32_t *bitrates, uint8_t num);
+    void *ctx; /* driver specific context */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CAN_INTERFACE_H */

--- a/can/can_manager.c
+++ b/can/can_manager.c
@@ -1,0 +1,130 @@
+#include "can_manager.h"
+#include "can_config.h"
+#include <string.h>
+
+#define MAX_CAN_INTERFACES 4
+
+typedef struct {
+    CAN_Message_t tx_queue[CAN_TX_QUEUE_LEN];
+    uint16_t tx_head, tx_tail;
+    CAN_Message_t rx_queue[CAN_RX_QUEUE_LEN];
+    uint16_t rx_head, rx_tail;
+} CAN_Buffer_t;
+
+typedef struct {
+    ICANDriver *driver;
+    CAN_Callback_t callbacks[3];
+    CAN_Buffer_t buffers;
+} CAN_Instance_t;
+
+static CAN_Instance_t can_instances[MAX_CAN_INTERFACES];
+static uint8_t can_instances_count = 0;
+
+static void CAN_Manager_TriggerEvent(uint8_t inst_id, CAN_Event_t event, void *arg);
+
+void CAN_Manager_Init(void)
+{
+    memset(can_instances, 0, sizeof(can_instances));
+    can_instances_count = 0;
+}
+
+int CAN_Manager_AddInterface(ICANDriver *driver, const CAN_Config_t *config)
+{
+    if (can_instances_count >= MAX_CAN_INTERFACES || !driver || !driver->init) {
+        return -1;
+    }
+    if (driver->init(driver, config) != CAN_OK) {
+        return -1;
+    }
+    can_instances[can_instances_count].driver = driver;
+    memset(can_instances[can_instances_count].callbacks, 0, sizeof(CAN_Callback_t) * 3);
+    CAN_Buffer_t *buf = &can_instances[can_instances_count].buffers;
+    buf->tx_head = buf->tx_tail = 0;
+    buf->rx_head = buf->rx_tail = 0;
+    return can_instances_count++;
+}
+
+CAN_Result_t CAN_SendMessage(uint8_t inst_id, const CAN_Message_t *msg)
+{
+    if (inst_id >= can_instances_count) {
+        return CAN_ERROR;
+    }
+    CAN_Buffer_t *buf = &can_instances[inst_id].buffers;
+    uint16_t next = (buf->tx_head + 1) % CAN_TX_QUEUE_LEN;
+    if (next == buf->tx_tail)
+        return CAN_ERROR; /* full */
+    buf->tx_queue[buf->tx_head] = *msg;
+    buf->tx_head = next;
+    return CAN_OK;
+}
+
+void CAN_RegisterCallback(uint8_t inst_id, CAN_Event_t event, CAN_Callback_t cb)
+{
+    if (inst_id >= can_instances_count || event > CAN_EVENT_ERROR)
+        return;
+    can_instances[inst_id].callbacks[event] = cb;
+}
+
+int CAN_GetMessage(uint8_t inst_id, CAN_Message_t *msg)
+{
+    if (inst_id >= can_instances_count || !msg)
+        return -1;
+    CAN_Buffer_t *buf = &can_instances[inst_id].buffers;
+    if (buf->rx_head == buf->rx_tail)
+        return -1;
+    *msg = buf->rx_queue[buf->rx_tail];
+    buf->rx_tail = (buf->rx_tail + 1) % CAN_RX_QUEUE_LEN;
+    return 0;
+}
+
+CAN_Result_t CAN_StartAutoBaud(uint8_t inst_id, const uint32_t *rates, uint8_t num)
+{
+    if (inst_id >= can_instances_count)
+        return CAN_ERROR;
+    ICANDriver *drv = can_instances[inst_id].driver;
+    if (drv && drv->auto_baud_detect) {
+        return drv->auto_baud_detect(drv, rates, num);
+    }
+    return CAN_ERROR;
+}
+
+void CAN_Manager_Process(void)
+{
+    for (uint8_t i = 0; i < can_instances_count; ++i) {
+        CAN_Instance_t *inst = &can_instances[i];
+        ICANDriver *drv = inst->driver;
+        CAN_Buffer_t *buf = &inst->buffers;
+        if (!drv)
+            continue;
+
+        if (buf->tx_head != buf->tx_tail && drv->send) {
+            CAN_Message_t *msg = &buf->tx_queue[buf->tx_tail];
+            if (drv->send(drv, msg, 0) == CAN_OK) {
+                buf->tx_tail = (buf->tx_tail + 1) % CAN_TX_QUEUE_LEN;
+                CAN_Manager_TriggerEvent(i, CAN_EVENT_TX_COMPLETE, msg);
+            }
+        }
+
+        if (drv->receive) {
+            CAN_Message_t rx;
+            while (drv->receive(drv, &rx) == CAN_OK) {
+                uint16_t next = (buf->rx_head + 1) % CAN_RX_QUEUE_LEN;
+                if (next == buf->rx_tail)
+                    break; /* drop if full */
+                buf->rx_queue[buf->rx_head] = rx;
+                buf->rx_head = next;
+                CAN_Manager_TriggerEvent(i, CAN_EVENT_RX, &rx);
+            }
+        }
+    }
+}
+
+/* Example event trigger functions - would be called by driver implementations */
+void CAN_Manager_TriggerEvent(uint8_t inst_id, CAN_Event_t event, void *arg)
+{
+    if (inst_id >= can_instances_count)
+        return;
+    CAN_Callback_t cb = can_instances[inst_id].callbacks[event];
+    if (cb)
+        cb(inst_id, event, arg);
+}

--- a/can/can_manager.h
+++ b/can/can_manager.h
@@ -1,0 +1,30 @@
+#ifndef CAN_MANAGER_H
+#define CAN_MANAGER_H
+
+#include "can_interface.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    CAN_EVENT_RX,
+    CAN_EVENT_TX_COMPLETE,
+    CAN_EVENT_ERROR
+} CAN_Event_t;
+
+typedef void (*CAN_Callback_t)(uint8_t inst_id, CAN_Event_t event, void *arg);
+
+void CAN_Manager_Init(void);
+int  CAN_Manager_AddInterface(ICANDriver *driver, const CAN_Config_t *config);
+CAN_Result_t CAN_SendMessage(uint8_t inst_id, const CAN_Message_t *msg);
+int CAN_GetMessage(uint8_t inst_id, CAN_Message_t *msg);
+void CAN_RegisterCallback(uint8_t inst_id, CAN_Event_t event, CAN_Callback_t cb);
+CAN_Result_t CAN_StartAutoBaud(uint8_t inst_id, const uint32_t *rates, uint8_t num);
+void CAN_Manager_Process(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CAN_MANAGER_H */

--- a/can/can_mcp2515.c
+++ b/can/can_mcp2515.c
@@ -1,0 +1,63 @@
+#include "can_mcp2515.h"
+#include <stdio.h>
+
+typedef struct {
+    /* hardware specific context placeholder */
+    int dummy;
+} MCP2515_Context;
+
+static CAN_Result_t mcp_init(ICANDriver *drv, const CAN_Config_t *cfg)
+{
+    (void)cfg;
+    drv->ctx = NULL;
+    return CAN_OK;
+}
+
+static CAN_Result_t mcp_send(ICANDriver *drv, const CAN_Message_t *msg, uint32_t timeout)
+{
+    (void)drv; (void)timeout;
+    if (msg)
+        printf("MCP2515 send id: 0x%lx\n", (unsigned long)msg->id);
+    return CAN_OK;
+}
+
+static CAN_Result_t mcp_receive(ICANDriver *drv, CAN_Message_t *msg)
+{
+    (void)drv; (void)msg;
+    return CAN_ERROR;
+}
+
+static CAN_Result_t mcp_set_filter(ICANDriver *drv, uint32_t id, uint32_t mask)
+{
+    (void)drv; (void)id; (void)mask;
+    return CAN_OK;
+}
+
+static CAN_Result_t mcp_set_mode(ICANDriver *drv, CAN_Mode_t mode)
+{
+    (void)drv; (void)mode;
+    return CAN_OK;
+}
+
+static uint32_t mcp_get_error(ICANDriver *drv)
+{
+    (void)drv;
+    return 0;
+}
+
+static CAN_Result_t mcp_autobaud(ICANDriver *drv, const uint32_t *rates, uint8_t num)
+{
+    (void)drv; (void)rates; (void)num;
+    return CAN_OK;
+}
+
+ICANDriver mcp2515_driver = {
+    .init = mcp_init,
+    .send = mcp_send,
+    .receive = mcp_receive,
+    .set_filter = mcp_set_filter,
+    .set_mode = mcp_set_mode,
+    .get_error_state = mcp_get_error,
+    .auto_baud_detect = mcp_autobaud,
+    .ctx = NULL
+};

--- a/can/can_mcp2515.h
+++ b/can/can_mcp2515.h
@@ -1,0 +1,8 @@
+#ifndef CAN_MCP2515_H
+#define CAN_MCP2515_H
+
+#include "can_interface.h"
+
+extern ICANDriver mcp2515_driver;
+
+#endif /* CAN_MCP2515_H */

--- a/can/can_stm32_bxcan.c
+++ b/can/can_stm32_bxcan.c
@@ -1,0 +1,57 @@
+#include "can_stm32_bxcan.h"
+#include <stdio.h>
+
+static CAN_Result_t bx_init(ICANDriver *drv, const CAN_Config_t *cfg)
+{
+    (void)cfg; (void)drv;
+    return CAN_OK;
+}
+
+static CAN_Result_t bx_send(ICANDriver *drv, const CAN_Message_t *msg, uint32_t timeout)
+{
+    (void)drv; (void)timeout;
+    if (msg)
+        printf("STM32 bxCAN send id: 0x%lx\n", (unsigned long)msg->id);
+    return CAN_OK;
+}
+
+static CAN_Result_t bx_receive(ICANDriver *drv, CAN_Message_t *msg)
+{
+    (void)drv; (void)msg;
+    return CAN_ERROR;
+}
+
+static CAN_Result_t bx_set_filter(ICANDriver *drv, uint32_t id, uint32_t mask)
+{
+    (void)drv; (void)id; (void)mask;
+    return CAN_OK;
+}
+
+static CAN_Result_t bx_set_mode(ICANDriver *drv, CAN_Mode_t mode)
+{
+    (void)drv; (void)mode;
+    return CAN_OK;
+}
+
+static uint32_t bx_get_error(ICANDriver *drv)
+{
+    (void)drv;
+    return 0;
+}
+
+static CAN_Result_t bx_autobaud(ICANDriver *drv, const uint32_t *rates, uint8_t num)
+{
+    (void)drv; (void)rates; (void)num;
+    return CAN_OK;
+}
+
+ICANDriver stm32_can1_driver = {
+    .init = bx_init,
+    .send = bx_send,
+    .receive = bx_receive,
+    .set_filter = bx_set_filter,
+    .set_mode = bx_set_mode,
+    .get_error_state = bx_get_error,
+    .auto_baud_detect = bx_autobaud,
+    .ctx = NULL
+};

--- a/can/can_stm32_bxcan.h
+++ b/can/can_stm32_bxcan.h
@@ -1,0 +1,8 @@
+#ifndef CAN_STM32_BXCAN_H
+#define CAN_STM32_BXCAN_H
+
+#include "can_interface.h"
+
+extern ICANDriver stm32_can1_driver;
+
+#endif /* CAN_STM32_BXCAN_H */

--- a/can/can_test.c
+++ b/can/can_test.c
@@ -1,0 +1,35 @@
+#include "can_manager.h"
+#include "can_mcp2515.h"
+#include "can_stm32_bxcan.h"
+#include "can_autobaud.h"
+#include "can_config.h"
+#include <stdio.h>
+
+static void on_rx(uint8_t id, CAN_Event_t ev, void *arg)
+{
+    (void)id; (void)ev; (void)arg;
+    printf("Message received callback\n");
+}
+
+int main(void)
+{
+    CAN_Config_t config = {
+        .mode = CAN_MODE_AUTOBAUD,
+        .bitrate = 0,
+        .filter_id = 0x100,
+        .filter_mask = 0x700
+    };
+
+    CAN_Manager_Init();
+    int id0 = CAN_Manager_AddInterface(&mcp2515_driver, &config);
+    int id1 = CAN_Manager_AddInterface(&stm32_can1_driver, &config);
+    printf("Interfaces %d %d added\n", id0, id1);
+
+    CAN_RegisterCallback(id0, CAN_EVENT_RX, on_rx);
+    CAN_Message_t msg = { .id = 0x123, .dlc = 1, .data = {0x55}, .extended = 0 };
+    CAN_SendMessage(id0, &msg);
+    CAN_Manager_Process();
+    CAN_StartAutoBaud(id0, default_bitrates, CAN_MAX_BITRATES);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- support transmit and receive queues for each CAN interface
- expose CAN_Message_t structure in driver API
- process queues via `CAN_Manager_Process`
- update example and README

## Testing
- `cc can/*.c -o can_test`
- `./can_test`

------
https://chatgpt.com/codex/tasks/task_e_68512c0779a88324bf92a538e1e137f2