### PR TITLE
Implement CAN manager event trigger API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # can_soft
+
+## CAN Manager API
+
+This repository contains minimal examples of a CAN manager with an event trigger API.
+Drivers should invoke `CAN_Manager_TriggerEvent` when a transmission completes,
+a message is received or an error occurs.

--- a/drivers/can_driver.c
+++ b/drivers/can_driver.c
@@ -1,0 +1,16 @@
+#include "can_manager.h"
+
+void CAN_Driver_OnTxComplete(uint32_t mailbox)
+{
+    CAN_Manager_TriggerEvent(CAN_EVENT_TX_COMPLETE, mailbox);
+}
+
+void CAN_Driver_OnRx(uint32_t msg_id)
+{
+    CAN_Manager_TriggerEvent(CAN_EVENT_RX_MSG, msg_id);
+}
+
+void CAN_Driver_OnError(uint32_t error)
+{
+    CAN_Manager_TriggerEvent(CAN_EVENT_ERROR, error);
+}

--- a/include/can_manager.h
+++ b/include/can_manager.h
@@ -1,0 +1,24 @@
+#ifndef CAN_MANAGER_H
+#define CAN_MANAGER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+typedef enum {
+    CAN_EVENT_TX_COMPLETE,
+    CAN_EVENT_RX_MSG,
+    CAN_EVENT_ERROR
+} CAN_Event_t;
+
+void CAN_Manager_Init(void);
+
+void CAN_Manager_TriggerEvent(CAN_Event_t event, uint32_t param);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CAN_MANAGER_H */

--- a/src/can_manager.c
+++ b/src/can_manager.c
@@ -1,0 +1,26 @@
+#include "can_manager.h"
+#include <stdio.h>
+
+void CAN_Manager_Init(void)
+{
+    /* Initialization code */
+}
+
+void CAN_Manager_TriggerEvent(CAN_Event_t event, uint32_t param)
+{
+    /* In a real implementation this would notify the manager */
+    /* For now simply print the event for demonstration */
+    switch(event) {
+        case CAN_EVENT_TX_COMPLETE:
+            printf("TX complete: %u\n", param);
+            break;
+        case CAN_EVENT_RX_MSG:
+            printf("RX message: %u\n", param);
+            break;
+        case CAN_EVENT_ERROR:
+            printf("Error: %u\n", param);
+            break;
+        default:
+            break;
+    }
+}


### PR DESCRIPTION
## Summary
- create minimal CAN manager header and source
- add example driver invoking CAN_Manager_TriggerEvent
- document the new API in README

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_6851384c31c88324bf22a5371d61224e