### PR TITLE
Support driver contexts in CAN manager

### DIFF
--- a/can/can_interface.h
+++ b/can/can_interface.h
@@ -35,6 +35,10 @@ typedef struct {
     uint8_t extended;
 } CAN_Message_t;
 
+typedef struct {
+    uint8_t inst_id;
+} CAN_DriverContext_t;
+
 struct ICANDriver {
     CAN_Result_t (*init)(ICANDriver *driver, const CAN_Config_t *config);
     CAN_Result_t (*send)(ICANDriver *driver, const CAN_Message_t *msg, uint32_t timeout_ms);

--- a/can/can_manager.c
+++ b/can/can_manager.c
@@ -13,6 +13,7 @@ typedef struct {
 
 typedef struct {
     ICANDriver *driver;
+    void *driver_ctx;
     CAN_Callback_t callbacks[3];
     CAN_Buffer_t buffers;
 } CAN_Instance_t;
@@ -38,12 +39,16 @@ int CAN_Manager_AddInterface(ICANDriver *driver, const CAN_Config_t *config)
         return -1;
     }
     can_instances[can_instances_count].driver = driver;
+    can_instances[can_instances_count].driver_ctx = driver->ctx;
     memset(can_instances[can_instances_count].callbacks, 0, sizeof(CAN_Callback_t) * 3);
     CAN_Buffer_t *buf = &can_instances[can_instances_count].buffers;
     buf->tx_head = buf->tx_tail = 0;
     buf->rx_head = buf->rx_tail = 0;
-    /* allow driver to know its instance id for external event reporting */
-    driver->ctx = (void*)(uintptr_t)can_instances_count;
+    /* store instance id in driver context if available */
+    if (driver->ctx) {
+        CAN_DriverContext_t *ctx = (CAN_DriverContext_t *)driver->ctx;
+        ctx->inst_id = can_instances_count;
+    }
     return can_instances_count++;
 }
 


### PR DESCRIPTION
## Summary
- add `CAN_DriverContext_t` base structure
- store driver context separately in `CAN_Instance_t`
- move MCP2515 driver state into its context
- refactor STM32 bxCAN driver to hold its HAL handle in context

## Testing
- `cc can/*.c -o can_test && ./can_test`

------
https://chatgpt.com/codex/tasks/task_e_68515afe07148324b3fcb821d665f98f