### PR TITLE
Add CAN_SetFilter API

### DIFF
--- a/can/can_manager.h
+++ b/can/can_manager.h
@@ -20,6 +20,7 @@ int  CAN_Manager_AddInterface(ICANDriver *driver, const CAN_Config_t *config);
 CAN_Result_t CAN_SendMessage(uint8_t inst_id, const CAN_Message_t *msg);
 int CAN_GetMessage(uint8_t inst_id, CAN_Message_t *msg);
 void CAN_RegisterCallback(uint8_t inst_id, CAN_Event_t event, CAN_Callback_t cb);
+CAN_Result_t CAN_SetFilter(uint8_t inst_id, uint32_t id, uint32_t mask);
 CAN_Result_t CAN_StartAutoBaud(uint8_t inst_id, const uint32_t *rates, uint8_t num);
 void CAN_Manager_Process(void);
 void CAN_Manager_TriggerEvent(uint8_t inst_id, CAN_Event_t event, void *arg);


### PR DESCRIPTION
## Summary
- expand `CAN_Instance_t` to track filter ID and mask
- add `CAN_SetFilter()` API in the manager

## Testing
- `cc can/*.c -o can_test && ./can_test | head`


------
https://chatgpt.com/codex/tasks/task_e_6851714db39c832497043f4bdf58fc0f