### PR TITLE
Refactor bxCAN driver for multiple instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ can/
 ├── can_interface.h     - abstract ICANDriver definition
 ├── can_manager.c/h     - manager for multiple CAN instances
 ├── can_mcp2515.c/h     - driver for MCP2515 controller
-├── can_stm32_bxcan.c/h - STM32 bxCAN driver using HAL
+├── can_stm32_bxcan.c/h - STM32 bxCAN driver with helper to create CAN1/CAN2/CAN3 instances
 └── can_test.c          - usage example
 ```
 
@@ -25,7 +25,7 @@ can/
 
 ## Building example
 
-`can_test.c` demonstrates adding two interfaces, enabling autobaud, configuring filters and loopback mode, sending messages and polling for reception.
+`can_test.c` demonstrates adding four interfaces (MCP2515 and three bxCAN instances for CAN1/CAN2/CAN3), enabling autobaud, configuring filters and loopback mode, sending messages and polling for reception.
 
 ```
 cc can/*.c -o can_test

--- a/can/can_stm32_bxcan.h
+++ b/can/can_stm32_bxcan.h
@@ -1,8 +1,15 @@
 #ifndef CAN_STM32_BXCAN_H
 #define CAN_STM32_BXCAN_H
 
-#include "can_interface.h"
 
-extern ICANDriver stm32_can1_driver;
+#include "can_interface.h"
+#include "stm32f1xx_hal.h"
+
+typedef struct {
+    CAN_DriverContext_t base;
+    CAN_HandleTypeDef   hcan;
+} BxCAN_Context;
+
+void BxCAN_SetupDriver(ICANDriver *driver, BxCAN_Context *ctx, CAN_TypeDef *inst);
 
 #endif /* CAN_STM32_BXCAN_H */


### PR DESCRIPTION
## Summary
- rework stm32 bxCAN driver to configure instances dynamically
- expose `BxCAN_SetupDriver` in the header
- show usage with three bxCAN controllers in the example
- mention bxCAN instance helper in README

## Testing
- `cc can/*.c -o can_test && ./can_test` *(fails: `stm32f1xx_hal.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852733442148324991d35476b39349f