### PR TITLE
Add FDCAN usage in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CAN Soft Module
 
-This repository contains a portable CAN bus management module written in pure C. The module allows the use of multiple CAN controllers simultaneously via a common `ICANDriver` interface. Example drivers for MCP2515 and STM32 bxCAN are provided. The bxCAN driver relies on the STM32 HAL libraries.
+This repository contains a portable CAN bus management module written in pure C. The module allows the use of multiple CAN controllers simultaneously via a common `ICANDriver` interface. Example drivers for MCP2515 and STM32 controllers are provided. The STM32 support now covers both the legacy **bxCAN** peripheral (used on F1/F2/F4 families) and the newer **FDCAN** peripheral found on the H7 series. All drivers rely on the corresponding STM32 HAL libraries.
 
 ## Directory structure
 
@@ -12,6 +12,7 @@ can/
 ├── can_manager.c/h     - manager for multiple CAN instances
 ├── can_mcp2515.c/h     - driver for MCP2515 controller
 ├── can_stm32_bxcan.c/h - STM32 bxCAN driver with helper to create CAN1/CAN2/CAN3 instances
+├── can_stm32_fdcan.c/h - STM32 FDCAN driver for H7 series
 └── can_test.c          - usage example
 ```
 
@@ -25,11 +26,11 @@ can/
 
 ## Building example
 
-`can_test.c` demonstrates adding four interfaces (MCP2515 and three bxCAN instances for CAN1/CAN2/CAN3), enabling autobaud, configuring filters and loopback mode, sending messages and polling for reception.
+`can_test.c` demonstrates adding four interfaces (MCP2515, two bxCAN instances for CAN1/CAN2 and one FDCAN interface). The example enables autobaud on the MCP2515 and FDCAN drivers, configures filters and loopback mode, sends messages and polls for reception.
 
 ```
 cc can/*.c -o can_test
 ./can_test
 ```
 
-To build the STM32 version of the driver make sure the STM32 HAL sources are in your include path and link the HAL libraries when compiling your firmware.
+To build the STM32 versions of the drivers make sure the appropriate HAL sources for your family (F1/F2/F4 for bxCAN or H7 for FDCAN) are in your include path and link the HAL libraries when compiling your firmware.

--- a/can/can_stm32_bxcan.c
+++ b/can/can_stm32_bxcan.c
@@ -1,8 +1,6 @@
 #include "can_stm32_bxcan.h"
 #include "can_manager.h"
 #include <stdio.h>
-#include "stm32f1xx_hal.h"
-#include "stm32f1xx_hal_can.h"
 
 /*
  * This driver demonstrates how the portable CAN layer can be connected to the

--- a/can/can_stm32_bxcan.h
+++ b/can/can_stm32_bxcan.h
@@ -3,7 +3,19 @@
 
 
 #include "can_interface.h"
-#include "stm32f1xx_hal.h"
+
+#if defined(STM32F1xx)
+#  include "stm32f1xx_hal.h"
+#  include "stm32f1xx_hal_can.h"
+#elif defined(STM32F2xx)
+#  include "stm32f2xx_hal.h"
+#  include "stm32f2xx_hal_can.h"
+#elif defined(STM32F4xx)
+#  include "stm32f4xx_hal.h"
+#  include "stm32f4xx_hal_can.h"
+#else
+#  error "Unsupported STM32 family for bxCAN"
+#endif
 
 typedef struct {
     CAN_DriverContext_t base;

--- a/can/can_stm32_fdcan.c
+++ b/can/can_stm32_fdcan.c
@@ -1,0 +1,181 @@
+#include "can_stm32_fdcan.h"
+#include "can_manager.h"
+#include <stdio.h>
+
+/* Simple FDCAN driver based on STM32 HAL */
+
+typedef struct {
+    CAN_DriverContext_t base;
+    FDCAN_HandleTypeDef hfdcan;
+} FDCAN_Context;
+
+static CAN_Result_t fd_set_filter(ICANDriver *drv, uint32_t id, uint32_t mask);
+static CAN_Result_t fd_set_mode(ICANDriver *drv, CAN_Mode_t mode);
+static void         fd_config_bitrate(FDCAN_Context *ctx, uint32_t bitrate);
+
+static CAN_Result_t fd_init(ICANDriver *drv, const CAN_Config_t *cfg)
+{
+    FDCAN_Context *ctx = (FDCAN_Context *)drv->ctx;
+    if (!ctx)
+        return CAN_ERROR;
+
+    fd_config_bitrate(ctx, cfg ? cfg->bitrate : 500000);
+    if (HAL_FDCAN_Start(&ctx->hfdcan) != HAL_OK)
+        return CAN_ERROR;
+
+    if (cfg) {
+        fd_set_filter(drv, cfg->filter_id, cfg->filter_mask);
+        fd_set_mode(drv, cfg->mode);
+    }
+    return CAN_OK;
+}
+
+static CAN_Result_t fd_send(ICANDriver *drv, const CAN_Message_t *msg, uint32_t timeout)
+{
+    (void)timeout;
+    if (!msg)
+        return CAN_ERROR;
+    FDCAN_TxHeaderTypeDef hdr = {
+        .Identifier = msg->id,
+        .IdType = msg->extended ? FDCAN_EXTENDED_ID : FDCAN_STANDARD_ID,
+        .TxFrameType = FDCAN_DATA_FRAME,
+        .DataLength = msg->dlc << 16,
+        .ErrorStateIndicator = FDCAN_ESI_ACTIVE,
+        .BitRateSwitch = FDCAN_BRS_OFF,
+        .FDFormat = FDCAN_CLASSIC_CAN,
+        .TxEventFifoControl = FDCAN_NO_TX_EVENTS,
+        .MessageMarker = 0
+    };
+    FDCAN_Context *ctx = (FDCAN_Context *)drv->ctx;
+    if (HAL_FDCAN_AddMessageToTxFifoQ(&ctx->hfdcan, &hdr, msg->data) != HAL_OK)
+        return CAN_ERROR;
+    CAN_Manager_TriggerEvent(ctx->base.inst_id, CAN_EVENT_TX_COMPLETE, (void *)msg);
+    return CAN_OK;
+}
+
+static CAN_Result_t fd_receive(ICANDriver *drv, CAN_Message_t *msg)
+{
+    FDCAN_RxHeaderTypeDef hdr;
+    FDCAN_Context *ctx = (FDCAN_Context *)drv->ctx;
+    if (!msg)
+        return CAN_ERROR;
+    if (HAL_FDCAN_GetRxMessage(&ctx->hfdcan, FDCAN_RX_FIFO0, &hdr, msg->data) == HAL_OK) {
+        msg->id = hdr.Identifier;
+        msg->extended = (hdr.IdType == FDCAN_EXTENDED_ID) ? 1 : 0;
+        msg->dlc = hdr.DataLength >> 16;
+        CAN_Manager_TriggerEvent(ctx->base.inst_id, CAN_EVENT_RX, msg);
+        return CAN_OK;
+    }
+    return CAN_ERROR;
+}
+
+static CAN_Result_t fd_set_filter(ICANDriver *drv, uint32_t id, uint32_t mask)
+{
+    FDCAN_Context *ctx = (FDCAN_Context *)drv->ctx;
+    FDCAN_FilterTypeDef f = {
+        .IdType = FDCAN_EXTENDED_ID,
+        .FilterIndex = 0,
+        .FilterType = FDCAN_FILTER_MASK,
+        .FilterConfig = FDCAN_FILTER_TO_RXFIFO0,
+        .FilterID1 = id,
+        .FilterID2 = mask
+    };
+    HAL_FDCAN_ConfigFilter(&ctx->hfdcan, &f);
+    return CAN_OK;
+}
+
+static CAN_Result_t fd_set_mode(ICANDriver *drv, CAN_Mode_t mode)
+{
+    FDCAN_Context *ctx = (FDCAN_Context *)drv->ctx;
+    uint32_t opmode = FDCAN_OPERATION_MODE_NORMAL;
+    switch (mode) {
+    case CAN_MODE_LOOPBACK:
+        opmode = FDCAN_OPERATION_MODE_INTERNAL_LOOPBACK;
+        break;
+    case CAN_MODE_SILENT:
+    case CAN_MODE_AUTOBAUD:
+        opmode = FDCAN_OPERATION_MODE_BUS_MONITORING;
+        break;
+    case CAN_MODE_NORMAL:
+    default:
+        opmode = FDCAN_OPERATION_MODE_NORMAL;
+        break;
+    }
+    HAL_FDCAN_Stop(&ctx->hfdcan);
+    ctx->hfdcan.Init.Mode = opmode;
+    HAL_FDCAN_Init(&ctx->hfdcan);
+    return HAL_FDCAN_Start(&ctx->hfdcan) == HAL_OK ? CAN_OK : CAN_ERROR;
+}
+
+static void fd_config_bitrate(FDCAN_Context *ctx, uint32_t bitrate)
+{
+    const uint32_t pclk = 48000000U;
+    const uint32_t tq = 16U;
+    ctx->hfdcan.Init.NominalPrescaler = pclk / (bitrate * tq);
+    ctx->hfdcan.Init.NominalSyncJumpWidth = 1;
+    ctx->hfdcan.Init.NominalTimeSeg1 = 13;
+    ctx->hfdcan.Init.NominalTimeSeg2 = 2;
+    HAL_FDCAN_Init(&ctx->hfdcan);
+}
+
+static uint32_t fd_get_error(ICANDriver *drv)
+{
+    FDCAN_Context *ctx = (FDCAN_Context *)drv->ctx;
+    return HAL_FDCAN_GetError(&ctx->hfdcan);
+}
+
+static CAN_Result_t fd_autobaud(ICANDriver *drv, const uint32_t *rates, uint8_t num)
+{
+    if (!drv || !rates || num == 0)
+        return CAN_ERROR;
+
+    FDCAN_Context *ctx = (FDCAN_Context *)drv->ctx;
+    CAN_Message_t msg;
+
+    for (uint8_t i = 0; i < num; ++i) {
+        uint32_t br = rates[i];
+        if (br == 0)
+            continue;
+
+        HAL_FDCAN_Stop(&ctx->hfdcan);
+        ctx->hfdcan.Init.Mode = FDCAN_OPERATION_MODE_BUS_MONITORING;
+        fd_config_bitrate(ctx, br);
+        HAL_FDCAN_Start(&ctx->hfdcan);
+        printf("FDCAN autobaud try %lu\n", (unsigned long)br);
+
+        for (int attempt = 0; attempt < 100; ++attempt) {
+            if (fd_receive(drv, &msg) == CAN_OK) {
+                printf("FDCAN autobaud detected %lu\n", (unsigned long)br);
+                HAL_FDCAN_Stop(&ctx->hfdcan);
+                ctx->hfdcan.Init.Mode = FDCAN_OPERATION_MODE_NORMAL;
+                fd_config_bitrate(ctx, br);
+                HAL_FDCAN_Start(&ctx->hfdcan);
+                return CAN_OK;
+            }
+        }
+    }
+
+    return CAN_ERROR;
+}
+
+static ICANDriver fd_template = {
+    .init            = fd_init,
+    .send            = fd_send,
+    .receive         = fd_receive,
+    .set_filter      = fd_set_filter,
+    .set_mode        = fd_set_mode,
+    .get_error_state = fd_get_error,
+    .auto_baud_detect = fd_autobaud,
+    .ctx             = NULL
+};
+
+void FDCAN_SetupDriver(ICANDriver *drv, FDCAN_Context *ctx, FDCAN_GlobalTypeDef *inst)
+{
+    if (!drv || !ctx)
+        return;
+
+    *drv = fd_template;
+    ctx->hfdcan.Instance = inst;
+    drv->ctx = ctx;
+}
+

--- a/can/can_stm32_fdcan.h
+++ b/can/can_stm32_fdcan.h
@@ -1,0 +1,20 @@
+#ifndef CAN_STM32_FDCAN_H
+#define CAN_STM32_FDCAN_H
+
+#include "can_interface.h"
+
+#if defined(STM32H7xx)
+#include "stm32h7xx_hal.h"
+#include "stm32h7xx_hal_fdcan.h"
+#else
+#error "Unsupported STM32 family for FDCAN"
+#endif
+
+typedef struct {
+    CAN_DriverContext_t base;
+    FDCAN_HandleTypeDef hfdcan;
+} FDCAN_Context;
+
+void FDCAN_SetupDriver(ICANDriver *driver, FDCAN_Context *ctx, FDCAN_GlobalTypeDef *inst);
+
+#endif /* CAN_STM32_FDCAN_H */

--- a/can/can_test.c
+++ b/can/can_test.c
@@ -1,6 +1,7 @@
 #include "can_manager.h"
 #include "can_mcp2515.h"
 #include "can_stm32_bxcan.h"
+#include "can_stm32_fdcan.h"
 #include "can_autobaud.h"
 #include "can_config.h"
 #include <stdio.h>
@@ -40,14 +41,15 @@ int main(void)
 
     CAN_Manager_Init();
     int id0 = CAN_Manager_AddInterface(&mcp2515_driver, &cfg0);
-    BxCAN_Context bx1, bx2, bx3;
-    ICANDriver d1, d2, d3;
-    BxCAN_SetupDriver(&d1, &bx1, CAN1);
-    BxCAN_SetupDriver(&d2, &bx2, CAN2);
-    BxCAN_SetupDriver(&d3, &bx3, CAN3);
-    int id1 = CAN_Manager_AddInterface(&d1, &cfg1);
-    int id2 = CAN_Manager_AddInterface(&d2, &cfg1);
-    int id3 = CAN_Manager_AddInterface(&d3, &cfg1);
+    BxCAN_Context bx1, bx2;
+    FDCAN_Context fd1;
+    ICANDriver bx_drv1, bx_drv2, fd_drv;
+    BxCAN_SetupDriver(&bx_drv1, &bx1, CAN1);
+    BxCAN_SetupDriver(&bx_drv2, &bx2, CAN2);
+    FDCAN_SetupDriver(&fd_drv, &fd1, FDCAN1);
+    int id1 = CAN_Manager_AddInterface(&bx_drv1, &cfg1);
+    int id2 = CAN_Manager_AddInterface(&bx_drv2, &cfg1);
+    int id3 = CAN_Manager_AddInterface(&fd_drv, &cfg1);
     printf("Interfaces %d %d %d %d added\n", id0, id1, id2, id3);
 
     CAN_RegisterCallback(id0, CAN_EVENT_RX, on_rx);
@@ -63,8 +65,9 @@ int main(void)
     CAN_RegisterCallback(id3, CAN_EVENT_TX_COMPLETE, on_tx);
     CAN_RegisterCallback(id3, CAN_EVENT_ERROR, on_err);
 
-    /* Autobaud on interface 0 */
+    /* Autobaud on MCP2515 and FDCAN interfaces */
     CAN_StartAutoBaud(id0, default_bitrates, CAN_MAX_BITRATES);
+    CAN_StartAutoBaud(id3, default_bitrates, CAN_MAX_BITRATES);
 
     /* Adjust filter and loopback mode directly via driver */
     mcp2515_driver.set_filter(&mcp2515_driver, 0x200, 0x7FF);
@@ -98,11 +101,11 @@ int main(void)
     printf("Error state iface %d: %lu\n", id0,
            (unsigned long)mcp2515_driver.get_error_state(&mcp2515_driver));
     printf("Error state iface %d: %lu\n", id1,
-           (unsigned long)d1.get_error_state(&d1));
+           (unsigned long)bx_drv1.get_error_state(&bx_drv1));
     printf("Error state iface %d: %lu\n", id2,
-           (unsigned long)d2.get_error_state(&d2));
+           (unsigned long)bx_drv2.get_error_state(&bx_drv2));
     printf("Error state iface %d: %lu\n", id3,
-           (unsigned long)d3.get_error_state(&d3));
+           (unsigned long)fd_drv.get_error_state(&fd_drv));
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- update README description of example
- extend `can_test.c` to showcase a new FDCAN interface with autobaud

## Testing
- `cc can/*.c -o can_test` *(fails: missing STM32 HAL headers)*

------
https://chatgpt.com/codex/tasks/task_e_685287d5174c83249ab7ea1bbc0513ea