### PR TITLE
Expose MAX_CAN_INTERFACES config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ cc can/*.c -o can_test
 ```
 
 To build the STM32 versions of the drivers make sure the appropriate HAL sources for your family (F1/F2/F4 for bxCAN or H7 for FDCAN) are in your include path and link the HAL libraries when compiling your firmware.
+
+## Configuration
+
+The number of CAN interfaces managed by `can_manager.c` is controlled by the
+`MAX_CAN_INTERFACES` macro defined in `can/can_config.h`.  It defaults to `4`,
+but can be overridden at compile time using the `-D` flag, e.g.:
+
+```sh
+cc -DMAX_CAN_INTERFACES=8 ...
+```

--- a/can/can_config.h
+++ b/can/can_config.h
@@ -5,6 +5,10 @@
 
 #define CAN_MAX_BITRATES 4
 
+#ifndef MAX_CAN_INTERFACES
+#define MAX_CAN_INTERFACES 4
+#endif
+
 static const uint32_t default_bitrates[CAN_MAX_BITRATES] = {125000, 250000, 500000, 1000000};
 
 #ifndef CAN_TX_QUEUE_LEN

--- a/can/can_manager.c
+++ b/can/can_manager.c
@@ -2,8 +2,6 @@
 #include "can_config.h"
 #include <string.h>
 
-#define MAX_CAN_INTERFACES 4
-
 typedef struct {
     CAN_Message_t tx_queue[CAN_TX_QUEUE_LEN];
     uint16_t tx_head, tx_tail;


### PR DESCRIPTION
## Summary
- make number of CAN manager slots configurable in `can_config.h`
- remove hard-coded value from `can_manager.c`
- document override in README

## Testing
- `cc -c can/can_manager.c -o /tmp/can_manager.o && echo "build success"`

------
https://chatgpt.com/codex/tasks/task_e_6853c6995e108324bb676525de5dd7e9