### PR TITLE
Add interrupt support for STM32 CAN drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ can/
 - Automatic bitrate detection helper
 - Simple API for sending messages and polling receive buffers
 - Direct access to driver functions for filters, modes and error queries
+- Optional interrupt driven operation when supported by the driver
 
 ## Building example
 
-`can_test.c` demonstrates adding four interfaces (MCP2515, two bxCAN instances for CAN1/CAN2 and one FDCAN interface). The example enables autobaud on the MCP2515 and FDCAN drivers, configures filters and loopback mode, sends messages and polls for reception.
+`can_test.c` demonstrates adding four interfaces (MCP2515, two bxCAN instances for CAN1/CAN2 and one FDCAN interface). The example enables autobaud on the MCP2515 and FDCAN drivers, configures filters and loopback mode, sends messages and uses either polling or interrupts for reception.
 
 ```
 cc can/*.c -o can_test

--- a/can/can_interface.h
+++ b/can/can_interface.h
@@ -19,6 +19,7 @@ typedef struct {
     uint32_t filter_id;
     uint32_t filter_mask;
     CAN_Mode_t mode;
+    uint8_t use_interrupts;
 } CAN_Config_t;
 
 typedef enum {
@@ -47,6 +48,9 @@ struct ICANDriver {
     CAN_Result_t (*set_mode)(ICANDriver *driver, CAN_Mode_t mode);
     uint32_t     (*get_error_state)(ICANDriver *driver);
     CAN_Result_t (*auto_baud_detect)(ICANDriver *driver, const uint32_t *bitrates, uint8_t num);
+    void         (*enable_interrupts)(ICANDriver *driver);
+    void         (*disable_interrupts)(ICANDriver *driver);
+    void         (*irq_handler)(ICANDriver *driver);
     void *ctx; /* driver specific context */
 };
 

--- a/can/can_mcp2515.c
+++ b/can/can_mcp2515.c
@@ -101,5 +101,8 @@ ICANDriver mcp2515_driver = {
     .set_mode = mcp_set_mode,
     .get_error_state = mcp_get_error,
     .auto_baud_detect = mcp_autobaud,
+    .enable_interrupts = NULL,
+    .disable_interrupts = NULL,
+    .irq_handler = NULL,
     .ctx = NULL
 };

--- a/can/can_stm32_bxcan.h
+++ b/can/can_stm32_bxcan.h
@@ -20,6 +20,7 @@
 typedef struct {
     CAN_DriverContext_t base;
     CAN_HandleTypeDef   hcan;
+    ICANDriver         *driver;
 } BxCAN_Context;
 
 void BxCAN_SetupDriver(ICANDriver *driver, BxCAN_Context *ctx, CAN_TypeDef *inst);

--- a/can/can_stm32_fdcan.h
+++ b/can/can_stm32_fdcan.h
@@ -13,6 +13,7 @@
 typedef struct {
     CAN_DriverContext_t base;
     FDCAN_HandleTypeDef hfdcan;
+    ICANDriver         *driver;
 } FDCAN_Context;
 
 void FDCAN_SetupDriver(ICANDriver *driver, FDCAN_Context *ctx, FDCAN_GlobalTypeDef *inst);

--- a/can/can_test.c
+++ b/can/can_test.c
@@ -30,13 +30,15 @@ int main(void)
         .mode = CAN_MODE_AUTOBAUD,
         .bitrate = 0,
         .filter_id = 0x100,
-        .filter_mask = 0x700
+        .filter_mask = 0x700,
+        .use_interrupts = 0
     };
     CAN_Config_t cfg1 = {
         .mode = CAN_MODE_NORMAL,
         .bitrate = 500000,
         .filter_id = 0,
-        .filter_mask = 0
+        .filter_mask = 0,
+        .use_interrupts = 1
     };
 
     CAN_Manager_Init();
@@ -78,6 +80,11 @@ int main(void)
     CAN_SendMessage(id1, &msg);
     CAN_SendMessage(id2, &msg);
     CAN_SendMessage(id3, &msg);
+
+    /* Simulate IRQ handlers being called */
+    if (bx_drv1.irq_handler) bx_drv1.irq_handler(&bx_drv1);
+    if (bx_drv2.irq_handler) bx_drv2.irq_handler(&bx_drv2);
+    if (fd_drv.irq_handler) fd_drv.irq_handler(&fd_drv);
 
     for (int i = 0; i < 3; ++i) {
         CAN_Manager_Process();


### PR DESCRIPTION
## Summary
- extend `CAN_Config_t` with `use_interrupts`
- provide optional interrupt hooks in `ICANDriver`
- use the new hooks in the CAN manager
- implement interrupt handlers in STM32 bxCAN and FDCAN drivers
- update example for interrupt mode
- document optional interrupt operation

## Testing
- `cc can/*.c -o can_test` *(fails: unsupported STM32 HAL headers)*

------
https://chatgpt.com/codex/tasks/task_e_6853d12f35c08324bffbd46de60a2d26